### PR TITLE
Remove an ' in your url

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -4,7 +4,7 @@ email:       james@smithjw.me
 author:      James Smith
 description: "A Blog about everything and nothing"
 baseurl:     ""
-url:         "https://smithjw.github.io'"
+url:         "https://smithjw.github.io"
 date_format: "%b %-d, %Y"
 
 # Google services


### PR DESCRIPTION
It's causing your site to 404 when you click on "James' Ubiquitious Blog" on the top of everypage